### PR TITLE
[GOG-533] Modified plugin to support wildcard include statement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/docs/index.md
+++ b/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/docs/index.md
@@ -1,0 +1,53 @@
+# Neptunia vapor
+
+## Has mente et
+
+Lorem markdownum aequora Famemque, a ramos regna Ulixem verba, posito qui
+nubilus membra. Pendet dixit canisve, hanc quoque animosa **veni**, inducere.
+Fer quem, mihi vallem; reposcunt aequoreae Haec, inposita. Eras dicere sic! Ore
+ad at nec pius rivi pectora Pandione amari pietas Ulixem.
+
+> Argenteus sinit. Corpore non Booten Uranie, in hac has dixi herbas. *Oculos
+> omnes Dixerat* suae coloribus et antris spernitque silva, dixit.
+
+Mihi [quamvis](http://caput-latebris.com/), ardua venit nam, de mox in et inquit
+incisa relevare reseminet Cycnus forma sororis. In mater artus utque iustis me
+vestrae magno datque, quaque multumque oscula iubemur.
+
+## Aditumque ubi
+
+Brevibus cervice inmunibus sunt peragit, [sua tanto
+insuper](http://ampycuslyncides.org/), arva ubi: torto mixta. Sanguis
+conscendunt sumit, utilis illo nec quaecumque ad urbis inpositaque. Alto sic
+esse resumere albet, pharetras sola, erat, [non longo
+paviunt](http://verba.org/) dives aurem. Nomina genus nulli insignia, carpere
+dare quo vident, *nox flemus sed* Telamon auras, erant illuc, tantum. Regia
+[duroque opto](http://www.flectathiberi.io/estredeunt), segetes paterna de
+crimen!
+
+    var edutainment_php = plain_ring_scan(adfUgcImap * delPanel);
+    var click_meta_dv = 3 +
+            systemScrollingDocument.snippetCdAnimated.memoryInstallHost(service(
+            bezel_trojan_plagiarism, 1, base_resources), intelligence,
+            umlWiSkin.software_olap.on(quadHocData));
+    var bare = jumper_server_solid - rupE + 3;
+    var timeRegistryStandby = disk_ppc_menu + gigahertzCifsRss;
+    if (im(correction_desktop, disk_integer_soft(serviceLogic, data_zone,
+            daw_ssid_web)) > graphicsExpansionBug + active) {
+        apiSpam = storageVisual + 3;
+    }
+
+Mors cum cum proturbat, gente nasci Semiramis sonum, toto est eris facto dapibus
+propulit; a! Rogantis ira canat, [in nec
+sanguine](http://acceptiordefensus.io/accepto) probro inmunesque molliter
+sustineat quem quamquam parentis non. Per **quod nec** rapit ipsa nec,
+territaque fallacis fluviis progenies aratro. Colla puer regesta si Haec
+silentia omen Paeonia, harenis puer Marmaridae pectora ingens miratur Thisbes
+veri. Plaga profugi, iram, praestans, pro hanc vehit, vites.
+
+Illa per acerris vivit difficile pulveris, faciebat pontus populabile utque? In
+flagrant umbrae marito, coniunx parari, **quoque sanguine Nisi**, ego
+[saxo](http://cervice-fessusque.com/), fovet, ait unda contigit. Gaudet in,
+herba quibus? Ore ne ambo mecumque pectoraque alta: viri illi in puer corpore
+expersque pharetra solutum proximitas. Gorgonis adempto, in montes terga quae
+nec remoratur nives perque insidias exsiluit tribuitque mille.

--- a/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/mkdocs.yml
+++ b/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: "Example"
+site_description: "Description Here"
+
+docs_dir: ./docs
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: "index.md"
+  - Subnav:
+    - index.md
+    - index.md
+  - "*include ": "!include mkdocs.yml"

--- a/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/projects/project-a/docs/README.md
+++ b/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/projects/project-a/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the ok-include-wildcard/project-a fixture.

--- a/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/projects/project-a/mkdocs.yml
+++ b/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/projects/project-a/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: 'test-a'
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md

--- a/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/projects/project-b/docs/README.md
+++ b/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/projects/project-b/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the ok-include-wildcard/project-b fixture.

--- a/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/projects/project-b/mkdocs.yml
+++ b/__tests__/integration/fixtures/error-include-wildcard-incomplete-statement/projects/project-b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: 'test-b'
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md

--- a/__tests__/integration/fixtures/error-include-wildcard-no-site-name/docs/index.md
+++ b/__tests__/integration/fixtures/error-include-wildcard-no-site-name/docs/index.md
@@ -1,0 +1,53 @@
+# Neptunia vapor
+
+## Has mente et
+
+Lorem markdownum aequora Famemque, a ramos regna Ulixem verba, posito qui
+nubilus membra. Pendet dixit canisve, hanc quoque animosa **veni**, inducere.
+Fer quem, mihi vallem; reposcunt aequoreae Haec, inposita. Eras dicere sic! Ore
+ad at nec pius rivi pectora Pandione amari pietas Ulixem.
+
+> Argenteus sinit. Corpore non Booten Uranie, in hac has dixi herbas. *Oculos
+> omnes Dixerat* suae coloribus et antris spernitque silva, dixit.
+
+Mihi [quamvis](http://caput-latebris.com/), ardua venit nam, de mox in et inquit
+incisa relevare reseminet Cycnus forma sororis. In mater artus utque iustis me
+vestrae magno datque, quaque multumque oscula iubemur.
+
+## Aditumque ubi
+
+Brevibus cervice inmunibus sunt peragit, [sua tanto
+insuper](http://ampycuslyncides.org/), arva ubi: torto mixta. Sanguis
+conscendunt sumit, utilis illo nec quaecumque ad urbis inpositaque. Alto sic
+esse resumere albet, pharetras sola, erat, [non longo
+paviunt](http://verba.org/) dives aurem. Nomina genus nulli insignia, carpere
+dare quo vident, *nox flemus sed* Telamon auras, erant illuc, tantum. Regia
+[duroque opto](http://www.flectathiberi.io/estredeunt), segetes paterna de
+crimen!
+
+    var edutainment_php = plain_ring_scan(adfUgcImap * delPanel);
+    var click_meta_dv = 3 +
+            systemScrollingDocument.snippetCdAnimated.memoryInstallHost(service(
+            bezel_trojan_plagiarism, 1, base_resources), intelligence,
+            umlWiSkin.software_olap.on(quadHocData));
+    var bare = jumper_server_solid - rupE + 3;
+    var timeRegistryStandby = disk_ppc_menu + gigahertzCifsRss;
+    if (im(correction_desktop, disk_integer_soft(serviceLogic, data_zone,
+            daw_ssid_web)) > graphicsExpansionBug + active) {
+        apiSpam = storageVisual + 3;
+    }
+
+Mors cum cum proturbat, gente nasci Semiramis sonum, toto est eris facto dapibus
+propulit; a! Rogantis ira canat, [in nec
+sanguine](http://acceptiordefensus.io/accepto) probro inmunesque molliter
+sustineat quem quamquam parentis non. Per **quod nec** rapit ipsa nec,
+territaque fallacis fluviis progenies aratro. Colla puer regesta si Haec
+silentia omen Paeonia, harenis puer Marmaridae pectora ingens miratur Thisbes
+veri. Plaga profugi, iram, praestans, pro hanc vehit, vites.
+
+Illa per acerris vivit difficile pulveris, faciebat pontus populabile utque? In
+flagrant umbrae marito, coniunx parari, **quoque sanguine Nisi**, ego
+[saxo](http://cervice-fessusque.com/), fovet, ait unda contigit. Gaudet in,
+herba quibus? Ore ne ambo mecumque pectoraque alta: viri illi in puer corpore
+expersque pharetra solutum proximitas. Gorgonis adempto, in montes terga quae
+nec remoratur nives perque insidias exsiluit tribuitque mille.

--- a/__tests__/integration/fixtures/error-include-wildcard-no-site-name/mkdocs.yml
+++ b/__tests__/integration/fixtures/error-include-wildcard-no-site-name/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: "Example"
+site_description: "Description Here"
+
+docs_dir: ./docs
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: "index.md"
+  - Subnav:
+    - index.md
+    - index.md
+  - "*include ./projects/*": "!include mkdocs.yml"

--- a/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-a/docs/README.md
+++ b/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-a/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the ok-include-wildcard/project-a fixture.

--- a/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-a/mkdocs.yml
+++ b/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-a/mkdocs.yml
@@ -1,0 +1,7 @@
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md

--- a/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-b/docs/README.md
+++ b/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-b/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the ok-include-wildcard/project-b fixture.

--- a/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-b/mkdocs.yml
+++ b/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: 'test-b'
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md

--- a/__tests__/integration/fixtures/ok-include-wildcard/docs/index.md
+++ b/__tests__/integration/fixtures/ok-include-wildcard/docs/index.md
@@ -1,0 +1,53 @@
+# Neptunia vapor
+
+## Has mente et
+
+Lorem markdownum aequora Famemque, a ramos regna Ulixem verba, posito qui
+nubilus membra. Pendet dixit canisve, hanc quoque animosa **veni**, inducere.
+Fer quem, mihi vallem; reposcunt aequoreae Haec, inposita. Eras dicere sic! Ore
+ad at nec pius rivi pectora Pandione amari pietas Ulixem.
+
+> Argenteus sinit. Corpore non Booten Uranie, in hac has dixi herbas. *Oculos
+> omnes Dixerat* suae coloribus et antris spernitque silva, dixit.
+
+Mihi [quamvis](http://caput-latebris.com/), ardua venit nam, de mox in et inquit
+incisa relevare reseminet Cycnus forma sororis. In mater artus utque iustis me
+vestrae magno datque, quaque multumque oscula iubemur.
+
+## Aditumque ubi
+
+Brevibus cervice inmunibus sunt peragit, [sua tanto
+insuper](http://ampycuslyncides.org/), arva ubi: torto mixta. Sanguis
+conscendunt sumit, utilis illo nec quaecumque ad urbis inpositaque. Alto sic
+esse resumere albet, pharetras sola, erat, [non longo
+paviunt](http://verba.org/) dives aurem. Nomina genus nulli insignia, carpere
+dare quo vident, *nox flemus sed* Telamon auras, erant illuc, tantum. Regia
+[duroque opto](http://www.flectathiberi.io/estredeunt), segetes paterna de
+crimen!
+
+    var edutainment_php = plain_ring_scan(adfUgcImap * delPanel);
+    var click_meta_dv = 3 +
+            systemScrollingDocument.snippetCdAnimated.memoryInstallHost(service(
+            bezel_trojan_plagiarism, 1, base_resources), intelligence,
+            umlWiSkin.software_olap.on(quadHocData));
+    var bare = jumper_server_solid - rupE + 3;
+    var timeRegistryStandby = disk_ppc_menu + gigahertzCifsRss;
+    if (im(correction_desktop, disk_integer_soft(serviceLogic, data_zone,
+            daw_ssid_web)) > graphicsExpansionBug + active) {
+        apiSpam = storageVisual + 3;
+    }
+
+Mors cum cum proturbat, gente nasci Semiramis sonum, toto est eris facto dapibus
+propulit; a! Rogantis ira canat, [in nec
+sanguine](http://acceptiordefensus.io/accepto) probro inmunesque molliter
+sustineat quem quamquam parentis non. Per **quod nec** rapit ipsa nec,
+territaque fallacis fluviis progenies aratro. Colla puer regesta si Haec
+silentia omen Paeonia, harenis puer Marmaridae pectora ingens miratur Thisbes
+veri. Plaga profugi, iram, praestans, pro hanc vehit, vites.
+
+Illa per acerris vivit difficile pulveris, faciebat pontus populabile utque? In
+flagrant umbrae marito, coniunx parari, **quoque sanguine Nisi**, ego
+[saxo](http://cervice-fessusque.com/), fovet, ait unda contigit. Gaudet in,
+herba quibus? Ore ne ambo mecumque pectoraque alta: viri illi in puer corpore
+expersque pharetra solutum proximitas. Gorgonis adempto, in montes terga quae
+nec remoratur nives perque insidias exsiluit tribuitque mille.

--- a/__tests__/integration/fixtures/ok-include-wildcard/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-include-wildcard/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: "Example"
+site_description: "Description Here"
+
+docs_dir: ./docs
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: "index.md"
+  - Subnav:
+    - index.md
+    - index.md
+  - "*include ./projects/*/ Projects": "!include mkdocs.yml"

--- a/__tests__/integration/fixtures/ok-include-wildcard/projects/project-a/docs/README.md
+++ b/__tests__/integration/fixtures/ok-include-wildcard/projects/project-a/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the ok-include-wildcard/project-a fixture.

--- a/__tests__/integration/fixtures/ok-include-wildcard/projects/project-a/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-include-wildcard/projects/project-a/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: 'test-a'
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md

--- a/__tests__/integration/fixtures/ok-include-wildcard/projects/project-b/docs/README.md
+++ b/__tests__/integration/fixtures/ok-include-wildcard/projects/project-b/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the ok-include-wildcard/project-b fixture.

--- a/__tests__/integration/fixtures/ok-include-wildcard/projects/project-b/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-include-wildcard/projects/project-b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: 'test-b'
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md

--- a/__tests__/integration/test.bats
+++ b/__tests__/integration/test.bats
@@ -156,6 +156,27 @@ teardown() {
   assertSuccessMkdocs build
 }
 
+@test "builds a mkdocs site with single *include" {
+  cd ${fixturesDir}/ok-include-wildcard
+  assertSuccessMkdocs build
+  assertFileExists site/test-a/index.html
+  [[ "$output" == *"This contains a sentence which only exists in the ok-include-wildcard/project-a fixture."* ]]
+  assertFileExists site/test-b/index.html
+  [[ "$output" == *"This contains a sentence which only exists in the ok-include-wildcard/project-b fixture."* ]]
+}
+
+@test "builds a mkdocs site from a different folder with wildcard include" {
+  cd ${fixturesDir}
+  run mkdocs build --config-file=ok-include-wildcard/mkdocs.yml
+  debugger
+  run cat ok-include-wildcard/site/index.html
+  [[ "$output" == *"Lorem markdownum aequora Famemque"* ]]
+  run cat ok-include-wildcard/site/test-a/index.html
+  [[ "$output" == *"This contains a sentence which only exists in the ok-include-wildcard/project-a fixture."* ]]
+  run cat ok-include-wildcard/site/test-b/index.html
+  [[ "$output" == *"This contains a sentence which only exists in the ok-include-wildcard/project-b fixture."* ]]
+}
+
 @test "fails if !include path is above current folder" {
   cd ${fixturesDir}/error-include-path-is-parent
   assertFailedMkdocs build
@@ -205,8 +226,20 @@ teardown() {
   assertFileContains './site/index.html' 'href="http://www.absoluteurl.nl"'
   assertFileContains './site/index.html' 'href="https://www.absoluteurl.nl/sub/dir"'
   assertFileContains './site/index.html' 'href="ftp://ftp.absoluteurl.nl"'
-  
+
   assertFileContains './site/index.html' 'href="ftp://ftp.absoluteurl-root.nl"'
 
   [ "$status" -eq 0 ]
+}
+
+@test "fails if *include path is does not specify a path or title" {
+  cd ${fixturesDir}/error-include-wildcard-incomplete-statement
+  assertFailedMkdocs build
+  [[ "$output" == *"[mkdocs-monorepo] The wildcard include statement '*include ' does not include a path."* ]]
+}
+
+@test "fails if !include path from a wildcard include does not contain site_name" {
+  cd ${fixturesDir}/error-include-wildcard-no-site-name
+  assertFailedMkdocs build
+  [[ "$output" == *"[mkdocs-monorepo] The file path /"*"/__tests__/integration/fixtures/error-include-wildcard-no-site-name/projects/project-a/mkdocs.yml does not contain a valid 'site_name' key in the YAML file. Please include it to indicate where your documentation should be moved to."* ]]
 }

--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -75,12 +75,14 @@ class Parser:
 
         resolvedPaths = list(
             map(extractAliasAndPath, self.__loadAliasesAndResolvedPaths()))
+
         for alias, docsDir, ymlPath in resolvedPaths:
             if not os.path.exists(docsDir):
                 log.critical(
                     "[mkdocs-monorepo] The {} path is not valid. ".format(docsDir) +
                     "Please update your 'nav' with a valid path.")
                 raise SystemExit(1)
+
         return resolvedPaths
 
     def resolve(self, nav=None):
@@ -136,6 +138,7 @@ class Parser:
 
                 if nav[index][key] is None:
                     return None
+
         return nav
 
 

--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -63,6 +63,7 @@ class Parser:
                 paths.append(value[len(INCLUDE_STATEMENT):])
             elif type(value) is list:
                 paths.extend(self.__loadAliasesAndResolvedPaths(value))
+
         return paths
 
     def getResolvedPaths(self):

--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -120,7 +120,6 @@ class Parser:
                             try:
                                 with open(mkdocs_config, 'rb') as f:
                                     site_yaml = yaml_load(f)
-                                    # TODO add error checking
                                     site_name = site_yaml["site_name"]
                                 site[site_name] = f"{INCLUDE_STATEMENT}{mkdocs_config.resolve()}"
                                 value.append(site)

--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -45,16 +45,17 @@ class Parser:
             elif type(item) is dict:
                 key = list(item.keys())[0]
                 value = list(item.values())[0]
-                if key.startswith(WILDCARD_INCLUDE_STATEMENT):
+                if key.startswith(WILDCARD_INCLUDE_STATEMENT) and value.startswith(INCLUDE_STATEMENT):
                     base_path, *name = key[len(WILDCARD_INCLUDE_STATEMENT):].split()
                     key = " ".join(name)
-                    dirs = sorted(glob.glob(base_path))
+                    mkdocs_path = value[len(INCLUDE_STATEMENT):]
+                    dirs = sorted(glob.glob(f"{base_path}/{mkdocs_path}", recursive=True))
                     if dirs:
                         value = []
-                        for dir in dirs:
+                        for mkdocs_config in dirs:
                             site = {}
-                            if os.path.exists(f"{dir}/mkdocs.yml"):
-                                site[dir] = f"{INCLUDE_STATEMENT}{dir}/mkdocs.yml"
+                            if os.path.exists(mkdocs_config):
+                                site[mkdocs_config] = f"{INCLUDE_STATEMENT}{mkdocs_config}"
                                 value.append(site)
             else:
                 value = None
@@ -97,24 +98,23 @@ class Parser:
             elif type(item) is dict:
                 key = list(item.keys())[0]
                 value = list(item.values())[0]
-                if key.startswith(WILDCARD_INCLUDE_STATEMENT):
+                if key.startswith(WILDCARD_INCLUDE_STATEMENT) and value.startswith(INCLUDE_STATEMENT):
                     base_path, *name = key[len(WILDCARD_INCLUDE_STATEMENT):].split()
                     key = " ".join(name)
-
-                    dirs = sorted(glob.glob(base_path))
-
+                    mkdocs_path = value[len(INCLUDE_STATEMENT):]
+                    dirs = sorted(glob.glob(f"{base_path}/{mkdocs_path}", recursive=True))
                     if dirs:
                         value = []
-                        for dir in dirs:
+                        for mkdocs_config in dirs:
                             site = {}
                             try:
-                                with open(f"{dir}/mkdocs.yml", 'rb') as f:
+                                with open(mkdocs_config, 'rb') as f:
                                     site_yaml = yaml_load(f)
                                     site_name = site_yaml["site_name"]
-                                site[site_name] = f"{INCLUDE_STATEMENT}{dir}/mkdocs.yml"
+                                site[site_name] = f"{INCLUDE_STATEMENT}{mkdocs_config}"
                                 value.append(site)
                             except OSError as e:
-                                log.error(f"[mkdocs-monorepo] The {dir}/mkdocs.yml path is not valid.")
+                                log.error(f"[mkdocs-monorepo] The {mkdocs_config} path is not valid.")
                         # If not able to load mkdocs.yml from any of the directories
                         if not value:
                             return None

--- a/sample-docs/components/a/docs/README.md
+++ b/sample-docs/components/a/docs/README.md
@@ -1,0 +1,1 @@
+# Docs for A

--- a/sample-docs/components/a/mkdocs.yml
+++ b/sample-docs/components/a/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Component A
+
+nav:
+  - Home: "README.md"

--- a/sample-docs/components/b/docs/README.md
+++ b/sample-docs/components/b/docs/README.md
@@ -1,0 +1,1 @@
+# Docs for B

--- a/sample-docs/components/b/mkdocs.yml
+++ b/sample-docs/components/b/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Component B
+
+nav:
+  - Home: "README.md"

--- a/sample-docs/components/c/docs/README.md
+++ b/sample-docs/components/c/docs/README.md
@@ -1,0 +1,1 @@
+# Docs for C

--- a/sample-docs/components/c/mkdocs.yml
+++ b/sample-docs/components/c/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Component C
+
+nav:
+  - Home: "README.md"

--- a/sample-docs/components/d/README.md
+++ b/sample-docs/components/d/README.md
@@ -1,0 +1,1 @@
+# Component D

--- a/sample-docs/components/d/README.md
+++ b/sample-docs/components/d/README.md
@@ -1,1 +1,3 @@
 # Component D
+
+This will not be included

--- a/sample-docs/components/d/e/docs/README.md
+++ b/sample-docs/components/d/e/docs/README.md
@@ -1,0 +1,1 @@
+# Docs for E

--- a/sample-docs/components/d/e/mkdocs.yml
+++ b/sample-docs/components/d/e/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: Component E
+
+nav:
+  - Home: "README.md"

--- a/sample-docs/components/randomfile
+++ b/sample-docs/components/randomfile
@@ -1,0 +1,1 @@
+File present to test that it is successfully ignored by wildcard include.

--- a/sample-docs/mkdocs.yml
+++ b/sample-docs/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: Cats API
 nav:
   - Intro: 'index.md'
   - Authentication: 'authentication.md'
-  - '*include ./components/*/ Components': '!include .'
+  - '*include ./components/** Components': '!include mkdocs.yml'
   - API:
     - v1: '!include ./v1/mkdocs.yml'
     - v2: '!include ./v2/mkdocs.yml'

--- a/sample-docs/mkdocs.yml
+++ b/sample-docs/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: Cats API
 nav:
   - Intro: 'index.md'
   - Authentication: 'authentication.md'
-  - '*include ./components/* Components': '!include .'
+  - '*include ./components/*/ Components': '!include .'
   - API:
     - v1: '!include ./v1/mkdocs.yml'
     - v2: '!include ./v2/mkdocs.yml'

--- a/sample-docs/mkdocs.yml
+++ b/sample-docs/mkdocs.yml
@@ -3,6 +3,7 @@ site_name: Cats API
 nav:
   - Intro: 'index.md'
   - Authentication: 'authentication.md'
+  - '*include ./components/* Components': '!include .'
   - API:
     - v1: '!include ./v1/mkdocs.yml'
     - v2: '!include ./v2/mkdocs.yml'


### PR DESCRIPTION
This is a modified plugin based on https://github.com/backstage/mkdocs-monorepo-plugin that supports new syntax to enable including all of the docs for components (e.g in nitro-web or tempo) using a wildcard syntax rather than explicitly. There is a sample project in the mkdocs-monorepo-wildcard-plugin/sample-docs folder that demonstrates the syntax. 

```
site_name: Cats API

nav:
  - Intro: 'index.md'
  - Authentication: 'authentication.md'
  - '*include ./components/* Components': '!include mkdocs.yml'
...

plugins:
  - monorepo
  ```

